### PR TITLE
[TT-8739] Switch to chrome headless for testing

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -62,10 +62,9 @@ module.exports = function(config) {
     },
     autoWatch: true,
     frameworks: ["jasmine-jquery", "jasmine"],
-    browsers: ["Chrome"],
+    browsers: ["ChromeHeadless"],
     plugins: [
       "karma-chrome-launcher",
-      "karma-phantomjs-launcher",
       "karma-jasmine-jquery",
       "karma-jasmine",
       "karma-coverage",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "pretest": "eslint tags test",
-    "test": "karma start --single-run --browsers PhantomJS"
+    "test": "karma start --single-run"
   },
   "devDependencies": {
     "ckeditor": "^4.8.0",
@@ -26,12 +26,11 @@
     "jasmine-core": "^3.4.0",
     "jasmine-jquery": "^2.1.1",
     "jquery": "~3.5.0",
-    "karma": "^5.0.1",
-    "karma-chrome-launcher": "^3.0.0",
+    "karma": "^6.0.1",
+    "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.1",
     "karma-coveralls": "^2.1.0",
     "karma-jasmine": "^4.0.0",
-    "karma-jasmine-jquery": "^0.1.1",
-    "karma-phantomjs-launcher": "^1.0.4"
+    "karma-jasmine-jquery": "^0.1.1"
   }
 }


### PR DESCRIPTION
Since PhantomJS is deprecated it's blocking us from moving to karma
6.0.1, so let's switch since it's trivial.

Bumps [karma](https://github.com/karma-runner/karma) from 5.2.3 to 6.0.1.
- [Release notes](https://github.com/karma-runner/karma/releases)
- [Changelog](https://github.com/karma-runner/karma/blob/master/CHANGELOG.md)
- [Commits](https://github.com/karma-runner/karma/compare/v5.2.3...v6.0.1)